### PR TITLE
Added missing sudo command to ROCm installation instructions.

### DIFF
--- a/rocm_docs/tensorflow-build-from-source.md
+++ b/rocm_docs/tensorflow-build-from-source.md
@@ -8,7 +8,7 @@ This instruction provides a starting point for a ROCm installation of hiptensorf
 ```
 export ROCM_PATH=/opt/rocm
 export DEBIAN_FRONTEND noninteractive
-sudo apt update && apt install -y wget software-properties-common 
+sudo apt update && sudo apt install -y wget software-properties-common 
 ```
 
 Add the ROCm repository:  

--- a/rocm_docs/tensorflow-install-basic.md
+++ b/rocm_docs/tensorflow-install-basic.md
@@ -8,7 +8,7 @@ This instruction provides a starting point for a ROCm installation of hiptensorf
 ```
 export ROCM_PATH=/opt/rocm
 export DEBIAN_FRONTEND noninteractive
-sudo apt update && apt install -y wget software-properties-common 
+sudo apt update && sudo apt install -y wget software-properties-common 
 ```
 
 Add the ROCm repository:  


### PR DESCRIPTION
apt install usually needs superuser permissions.