### PR TITLE
Fix issue #62.

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -602,7 +602,8 @@ Status BaseGPUDeviceFactory::CreateGPUDevice(const SessionOptions& options,
       allocated_memory -= min_system_memory;
     }
   } else {
-    allocated_memory = total_memory * config_memory_fraction;
+    allocated_memory = std::min((int64) (total_memory * config_memory_fraction),
+		    available_memory);
   }
 
   Bytes allocated_bytes = static_cast<Bytes>(allocated_memory);


### PR DESCRIPTION
When the base GPU device factory creates a GPU device, a maximum of
available memory can be allocated rather than the total memory.
Otherwise, there will be a hipError_t(1002).